### PR TITLE
Invoker tests and updated MapCommandToInvoker

### DIFF
--- a/MonkeyArms/MonkeyArmsFramework/DI.cs
+++ b/MonkeyArms/MonkeyArmsFramework/DI.cs
@@ -43,7 +43,7 @@ namespace MonkeyArms
 				
 		}
 
-		public static void MapCommandToInvoker<TCommand, TInvoker> ()
+		public static TInvoker MapCommandToInvoker<TCommand, TInvoker> ()
 			where TCommand : Command
 			where TInvoker : Invoker
 		{
@@ -53,7 +53,7 @@ namespace MonkeyArms
 			var invoker = DI.Get<TInvoker> ();
 			invoker.AddCommand <TCommand>();
 
-
+			return invoker;
 		}
 
 		/*
@@ -123,7 +123,8 @@ namespace MonkeyArms
 		public static TGet Get<TGet> ()
 			where TGet : class
 		{
-
+			var t = typeof(TGet);
+			Console.WriteLine ("TGet {0}", t);
 			if (Instances.ContainsKey (typeof(TGet))) {
 				return Instances [typeof(TGet)] as TGet;
 			}

--- a/MonkeyArms/MonkeyArmsTests/DITests.cs
+++ b/MonkeyArms/MonkeyArmsTests/DITests.cs
@@ -57,6 +57,15 @@ namespace MonkeyArmsTests
 
 		}
 
+		[Test(Description="Assert MapCommandToInvoker maps command to invoker and correctly executes command when invoker is inline invoked")]
+		public void TestMapCommandToInvokerInlineInvoke ()
+		{
+			DI.MapSingleton<TestPM> ();
+			DI.MapCommandToInvoker<TestCommand1, TestInvoker> ().Invoke();
+			Assert.True (DI.Get<TestPM> ().Executed);
+
+		}
+
 		[Test(Description="Assert MapInstanceToSingleton returns instance of TestPM passed to it")]
 		public void TestMapInstanceToSingleTon()
 		{

--- a/MonkeyArms/MonkeyArmsTests/InvokerTests.cs
+++ b/MonkeyArms/MonkeyArmsTests/InvokerTests.cs
@@ -39,6 +39,34 @@ namespace MonkeyArmsTests
 
 		}
 
+		[Test(Description="Assert invoker calls Invoked event once Invoke complets")]
+		public void TestInvokerCallsInvoked ()
+		{
+			bool WasInvoked = false;
+			Invoker.Invoked += (object sender, EventArgs e) => {
+				WasInvoked = true;
+			};
+			Invoker.Invoke (new TestInvokerArgs("Hello World"));
+
+			Assert.IsTrue (WasInvoked);
+		}
+
+		[Test(Description="Assert an injected invoker calls Invoked event once Invoke complets")]
+		public void TestInjetedInvokerCallsInvoked ()
+		{
+			bool WasInvoked = false;
+			DI.MapSingleton<TestInvoker>();
+			DI.Get<TestInvoker>().Invoked += (object sender, EventArgs e) => {
+				WasInvoked = true;
+			};
+
+			DI.Get<TestInvoker>().Invoke (new TestInvokerArgs("Hello World"));
+
+			Assert.IsTrue (WasInvoked);
+
+
+		}
+
 	
 		/*
 		 * Test Classes


### PR DESCRIPTION
I added a couple tests to see that I could inject and use an invoker like I wanted. Also updated the mapping to return a TInvoker so I could immediate call .Invoke on it. All tests continue to pass.

Example 

DI.MapCommandToInvoker<ConfigureModelsCommand, ConfigureModelsInvoker> ().Invoke();
